### PR TITLE
allow configuring array of matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ transmission is configured for HTTP basic authentication.
         regexp: (match1|match2)
       - url: http://example.com/feed4
         download_path: /home/user/Downloads
+      - url: http://example.com/feed4
+        regexp:
+          - match1
+          - match2
 
     update_interval: 600
 

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -6,7 +6,7 @@ module TransmissionRSS
       case config
       when Hash
         @url = URI.encode(config['url'] || config.keys.first)
-        @regexp = Regexp.new(config['regexp'], Regexp::IGNORECASE) if config['regexp']
+        @regexp = build_regexp(config['regexp'])
         @download_path = config['download_path']
       else
         @url = config.to_s
@@ -15,6 +15,13 @@ module TransmissionRSS
 
     def matches_regexp?(title)
       @regexp.nil? || !(title =~ @regexp).nil?
+    end
+
+    protected
+
+    def build_regexp(matcher)
+      matcher = Array(matcher).map{ |m| Regexp.new(m,Regexp::IGNORECASE) }
+      matcher.empty? ? nil : Regexp.union(matcher)
     end
   end
 end

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -49,4 +49,11 @@ describe Feed do
     expect(feed.matches_regexp?("myfile.doc")).to eq(false)
     expect(feed.matches_regexp?("MYFILE.PDF")).to eq(true)
   end
+
+  it "should union array of regexes" do
+    feed = Feed.new("regexp" => ["foo", "bar"])
+    expect(feed.matches_regexp?("foo")).to be
+    expect(feed.matches_regexp?("bar")).to be
+    expect(feed.matches_regexp?("daz")).not_to be
+  end
 end


### PR DESCRIPTION
so you don't have to have one regex

I have plenty of matches in one feed, so it is growing out of hand
this does the same as unioning the regex by hand