### PR TITLE
Hash URLs in SeenFile and improve lookup performance; fixes #14.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /coverage
 /log
 /*.gem
-/spec/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /coverage
 /log
 /*.gem
+/spec/tmp

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -1,5 +1,3 @@
-require 'etc'
-require 'fileutils'
 require 'open-uri'
 require 'open_uri_redirections'
 require 'rss'

--- a/lib/transmission-rss/seen_file.rb
+++ b/lib/transmission-rss/seen_file.rb
@@ -3,11 +3,16 @@ require 'etc'
 module TransmissionRSS
   # Persist seen torrent URLs
   class SeenFile
+    extend Forwardable
+
     DEFAULT_LEGACY_PATH =
       File.join(Etc.getpwuid.dir, '.config/transmission/seen-torrents.conf')
 
     DEFAULT_PATH =
       File.join(Etc.getpwuid.dir, '.config/transmission/seen')
+    
+    def_delegator  :@seen, :clear, :clear!
+    def_delegators :@seen, :include?, :size, :to_a
 
     def initialize(path = nil, legacy_path = nil)
       @legacy_path = legacy_path || DEFAULT_LEGACY_PATH
@@ -29,22 +34,6 @@ module TransmissionRSS
       open(@legacy_path, 'a') do |f|
         f.write(url + "\n")
       end
-    end
-
-    def clear!
-      @seen.clear
-    end
-
-    def include?(url)
-      @seen.include?(url)
-    end
-
-    def size
-      @seen.size
-    end
-
-    def to_a
-      @seen.to_a
     end
 
     private

--- a/lib/transmission-rss/seen_file.rb
+++ b/lib/transmission-rss/seen_file.rb
@@ -1,5 +1,6 @@
 require 'digest'
 require 'etc'
+require 'fileutils'
 
 module TransmissionRSS
   # Persist seen torrent URLs

--- a/lib/transmission-rss/seen_file.rb
+++ b/lib/transmission-rss/seen_file.rb
@@ -1,0 +1,66 @@
+require 'etc'
+
+module TransmissionRSS
+  # Persist seen torrent URLs
+  class SeenFile
+    DEFAULT_LEGACY_PATH =
+      File.join(Etc.getpwuid.dir, '/.config/transmission/seen-torrents.conf')
+
+    DEFAULT_PATH =
+      File.join(Etc.getpwuid.dir, '/.config/transmission/seen')
+
+    def initialize(path = nil, legacy_path = nil)
+      legacy_path ||= DEFAULT_LEGACY_PATH
+      path        ||= DEFAULT_PATH
+
+      legacy = !Dir.exist?(path)
+
+      @legacy_path = legacy_path
+      @path        = path
+      @seen        = []
+
+      if legacy
+        initialize_legacy_path!
+
+        # Open file, read torrent URLs and add to +@seen+.
+        @seen = open(@legacy_path).readlines.map(&:chomp)
+      end
+    end
+
+    def add(url)
+      @seen << url
+
+      File.open(@legacy_path, 'w') do |file|
+        file.write(@seen.join("\n"))
+      end
+    end
+
+    def clear!
+      @seen.clear
+    end
+
+    def include?(url)
+      @seen.include?(url)
+    end
+
+    def size
+      @seen.size
+    end
+
+    def to_a
+      @seen.to_a
+    end
+
+    private
+
+    def initialize_legacy_path!
+      return if File.exist?(@legacy_path)
+
+      # Make directories in path if they are not existing.
+      FileUtils.mkdir_p(File.dirname(@legacy_path))
+
+      # Touch seen torrents store file.
+      FileUtils.touch(@legacy_path)
+    end
+  end
+end

--- a/lib/transmission-rss/seen_file.rb
+++ b/lib/transmission-rss/seen_file.rb
@@ -4,34 +4,30 @@ module TransmissionRSS
   # Persist seen torrent URLs
   class SeenFile
     DEFAULT_LEGACY_PATH =
-      File.join(Etc.getpwuid.dir, '/.config/transmission/seen-torrents.conf')
+      File.join(Etc.getpwuid.dir, '.config/transmission/seen-torrents.conf')
 
     DEFAULT_PATH =
-      File.join(Etc.getpwuid.dir, '/.config/transmission/seen')
+      File.join(Etc.getpwuid.dir, '.config/transmission/seen')
 
     def initialize(path = nil, legacy_path = nil)
-      legacy_path ||= DEFAULT_LEGACY_PATH
-      path        ||= DEFAULT_PATH
+      @legacy_path = legacy_path || DEFAULT_LEGACY_PATH
+      @path        = path || DEFAULT_PATH
 
-      legacy = !Dir.exist?(path)
+      @seen = Set.new
 
-      @legacy_path = legacy_path
-      @path        = path
-      @seen        = []
-
-      if legacy
+      if !File.exist?(@path)
         initialize_legacy_path!
 
         # Open file, read torrent URLs and add to +@seen+.
-        @seen = open(@legacy_path).readlines.map(&:chomp)
+        @seen = Set.new(open(@legacy_path).readlines.map(&:chomp))
       end
     end
 
     def add(url)
       @seen << url
 
-      File.open(@legacy_path, 'w') do |file|
-        file.write(@seen.join("\n"))
+      open(@legacy_path, 'a') do |f|
+        f.write(url + "\n")
       end
     end
 

--- a/spec/seen_file_spec.rb
+++ b/spec/seen_file_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SeenFile do
-  before do
+  before(:each, :init) do
     @seen_file = SeenFile.new('spec/tmp/a', 'spec/tmp/b')
     @url = 'http://example.com/foo'
 
@@ -9,7 +9,11 @@ describe SeenFile do
     @seen_file.add(@url)
   end
 
-  describe '#add' do
+  after do
+    FileUtils.rm_rf('spec/tmp')
+  end
+
+  describe '#add', :init do
     it 'saves entry in instance' do
       expect(@seen_file.include?(@url)).to be true
     end
@@ -19,7 +23,7 @@ describe SeenFile do
     end
   end
 
-  describe '#clear' do
+  describe '#clear', :init do
     it 'removes all entries' do
       @seen_file.clear!
 
@@ -28,9 +32,17 @@ describe SeenFile do
     end
   end
 
-  describe '#size' do
+  describe '#size', :init do
     it 'returns size' do
       expect(@seen_file.size).to eq(1)
     end
+  end
+
+  describe '.migrate!' do
+    before do
+      @seen_file = SeenFile.new('spec/tmp/a', 'spec/tmp/b')
+    end
+
+    pending
   end
 end

--- a/spec/seen_file_spec.rb
+++ b/spec/seen_file_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe SeenFile do
   before do
-    @seen_file = SeenFile.new('/tmp/rspec/a', '/tmp/rspec/b')
+    @seen_file = SeenFile.new('spec/tmp/a', 'spec/tmp/b')
     @url = 'http://example.com/foo'
 
     @seen_file.clear!

--- a/spec/seen_file_spec.rb
+++ b/spec/seen_file_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe SeenFile do
+  describe '#add' do
+    before do
+      @seen_file = SeenFile.new
+      @url = 'http://example.com/foo'
+
+      @seen_file.clear!
+      @seen_file.add(@url)
+    end
+
+    it 'saves entry in instance' do
+      expect(@seen_file.include?(@url)).to be true
+    end
+
+    it 'removes all entries' do
+      @seen_file.clear!
+
+      expect(@seen_file.size).to eq(0)
+      expect(@seen_file.include?(@url)).to be false
+    end
+
+    it 'returns size' do
+      expect(@seen_file.size).to eq(1)
+    end
+
+    it 'saves entry over instances' do
+      new_instance = SeenFile.new
+      expect(new_instance.include?(@url)).to be true
+    end
+  end
+end

--- a/spec/seen_file_spec.rb
+++ b/spec/seen_file_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
 
 describe SeenFile do
-  let(:a) { 'spec/tmp/a' }
-  let(:b) { 'spec/tmp/b' }
+  A = tmp_path(:a)
+  B = tmp_path(:b)
 
   before(:each, :init) do
-    @seen_file = SeenFile.new(a, b)
+    @seen_file = SeenFile.new(A, B)
     @url = 'http://example.com/foo'
 
     @seen_file.clear!
     @seen_file.add(@url)
   end
 
-  after do
-    FileUtils.rm_rf('spec/tmp')
+  after(:all) do
+    FileUtils.rm_rf(File.dirname(A))
   end
 
   describe '#add', :init do
@@ -22,7 +22,7 @@ describe SeenFile do
     end
 
     it 'saves entry over instances' do
-      expect(SeenFile.new.include?(@url)).to be true
+      expect(SeenFile.new(A, B).include?(@url)).to be true
     end
   end
 
@@ -42,23 +42,23 @@ describe SeenFile do
   end
 
   describe '#migrate!' do
-    subject { SeenFile.new(a, b) }
-    let(:urls) { ['http://example.com/foo', 'http://example.com/bar', nil] }
+    subject { SeenFile.new(A, B) }
+    let(:urls) { ['http://example.com/foo', 'http://example.com/bar'] }
 
     before do
-      FileUtils.mkdir_p(File.dirname(b))
-      open(b, 'w') { |f| f.write(urls.join("\n")) }
+      FileUtils.mkdir_p(File.dirname(B))
+      open(B, 'w') { |f| f.write(urls.join("\n") + "\n") }
     end
 
-    it 'new seen file should URLs from legacy one' do
-      urls.compact.each do |url|
+    it 'new seen file should include URLs from legacy one' do
+      urls.each do |url|
         expect(subject.include?(url)).to be true
       end
     end
   end
 
   describe '#file_to_array', :init do
-    subject { @seen_file.send(:file_to_array, a) }
+    subject { @seen_file.send(:file_to_array, A) }
     let(:hash) { @seen_file.send(:digest, @url) }
 
     it 'returns array' do

--- a/spec/seen_file_spec.rb
+++ b/spec/seen_file_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe SeenFile do
+  let(:a) { 'spec/tmp/a' }
+  let(:b) { 'spec/tmp/b' }
+
   before(:each, :init) do
-    @seen_file = SeenFile.new('spec/tmp/a', 'spec/tmp/b')
+    @seen_file = SeenFile.new(a, b)
     @url = 'http://example.com/foo'
 
     @seen_file.clear!
@@ -38,11 +41,37 @@ describe SeenFile do
     end
   end
 
-  describe '.migrate!' do
+  describe '#migrate!' do
+    subject { SeenFile.new(a, b) }
+    let(:urls) { ['http://example.com/foo', 'http://example.com/bar', nil] }
+
     before do
-      @seen_file = SeenFile.new('spec/tmp/a', 'spec/tmp/b')
+      FileUtils.mkdir_p(File.dirname(b))
+      open(b, 'w') { |f| f.write(urls.join("\n")) }
     end
 
-    pending
+    it 'new seen file should URLs from legacy one' do
+      urls.compact.each do |url|
+        expect(subject.include?(url)).to be true
+      end
+    end
+  end
+
+  describe '#file_to_array', :init do
+    subject { @seen_file.send(:file_to_array, a) }
+    let(:hash) { @seen_file.send(:digest, @url) }
+
+    it 'returns array' do
+      expect(subject).to be_a Array
+    end
+
+    it 'has correct size' do
+      expect(subject.empty?).to be false
+      expect(subject.size).to eq(1)
+    end
+
+    it 'has correct content' do
+      expect(subject.include?(hash)).to be true
+    end
   end
 end

--- a/spec/seen_file_spec.rb
+++ b/spec/seen_file_spec.rb
@@ -1,33 +1,36 @@
 require 'spec_helper'
 
 describe SeenFile do
+  before do
+    @seen_file = SeenFile.new('/tmp/rspec/a', '/tmp/rspec/b')
+    @url = 'http://example.com/foo'
+
+    @seen_file.clear!
+    @seen_file.add(@url)
+  end
+
   describe '#add' do
-    before do
-      @seen_file = SeenFile.new
-      @url = 'http://example.com/foo'
-
-      @seen_file.clear!
-      @seen_file.add(@url)
-    end
-
     it 'saves entry in instance' do
       expect(@seen_file.include?(@url)).to be true
     end
 
+    it 'saves entry over instances' do
+      expect(SeenFile.new.include?(@url)).to be true
+    end
+  end
+
+  describe '#clear' do
     it 'removes all entries' do
       @seen_file.clear!
 
       expect(@seen_file.size).to eq(0)
       expect(@seen_file.include?(@url)).to be false
     end
+  end
 
+  describe '#size' do
     it 'returns size' do
       expect(@seen_file.size).to eq(1)
-    end
-
-    it 'saves entry over instances' do
-      new_instance = SeenFile.new
-      expect(new_instance.include?(@url)).to be true
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ require File.join(basedir, 'lib', 'transmission-rss')
 
 include TransmissionRSS
 
+def tmp_path(file)
+  File.join(Dir.tmpdir, 'rspec', file.to_s)
+end
+
 Coveralls.wear!
 
 Log.instance.target = File.open(File.join(basedir, 'log', 'test.log'), 'a')


### PR DESCRIPTION
See #14.

* Save SHA256 hash of seen URLs.
* Migrate legacy plain seen file to hashed one on initialization.
* Use `Set` for in memory storage.