### PR TITLE
Add 'rpc_path' setting to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ transmission is configured for HTTP basic authentication.
     server:
       host: localhost
       port: 9091
+      rpc_path: /transmission/rpc
 
 	login:
 	  username: transmission

--- a/bin/transmission-add-file
+++ b/bin/transmission-add-file
@@ -62,7 +62,7 @@ end
 log.debug(config)
 
 # Initialize communication to transmission.
-client = Client.new(config.server.host, config.server.port)
+client = Client.new(config.server.host, config.server.port, config.server.rpc_path)
 
 ARGV.each do |torrent_file|
   client.add_torrent(torrent_file, :file, paused: config.add_paused)

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -129,7 +129,7 @@ end
 aggregator = Aggregator.new(config.feeds, seen_file: config.seen_file)
 
 # Initialize communication to transmission.
-client = Client.new(config.server.host, config.server.port, config.login)
+client = Client.new(config.server.host, config.server.port, config.server.rpc_path, config.login)
 
 # Callback for a new item on one of the feeds.
 aggregator.on_new_item do |torrent_file, feed, download_path|

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -10,8 +10,8 @@ module TransmissionRSS
     class Unauthorized < StandardError
     end
 
-    def initialize(host = 'localhost', port = 9091, login = nil, options = {})
-      @host, @port, @login = host, port, login
+    def initialize(host = 'localhost', port = 9091, rpc_path = '/transmission/rpc', login = nil, options = {})
+      @host, @port, @rpc_path, @login = host, port, rpc_path, login
       @timeout = options[:timeout] || 5
       @log = TransmissionRSS::Log.instance
     end
@@ -39,7 +39,7 @@ module TransmissionRSS
       raise Unauthorized unless sid
 
       post = Net::HTTP::Post.new \
-        '/transmission/rpc',
+        @rpc_path,
         {
           'Content-Type' => 'application/json',
           'X-Transmission-Session-Id' => sid
@@ -58,7 +58,7 @@ module TransmissionRSS
 
     # Get transmission session id.
     def get_session_id
-      get = Net::HTTP::Get.new('/transmission/rpc')
+      get = Net::HTTP::Get.new(@rpc_path)
 
       auth(get)
 

--- a/lib/transmission-rss/config.rb
+++ b/lib/transmission-rss/config.rb
@@ -42,7 +42,8 @@ module TransmissionRSS
         'add_paused' => false,
         'server' => {
           'host' => 'localhost',
-          'port' => 9091
+          'port' => 9091,
+          'rpc_path' => '/transmission/rpc'
         },
         'login' => nil,
         'log_target' => $stderr,


### PR DESCRIPTION
Added a setting for custom rpc paths to the config file. `/transmission/rpc` preserved as a default value.