### PR TITLE
Single run mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ notifications:
   email: false
 
 install:
-  - gem install bundler
+  - gem install bundler -v '< 2'
   - bundle install --jobs=3 --retry=3
 
 script:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ is true:
 ### All available options
 
 The following configuration file example contains every existing option
-(although `update_interval`, `add_paused`, `server`, `log`, `fork`, and
+(although `update_interval`, `add_paused`, `server`, `log`, `fork`, `single`, and
 `pid_file` are default values and could be omitted). The default `log.target` is
 STDERR. `privileges` is not defined by default, so the script runs as current
 user/group. `login` is also not defined by default. It has to be defined, if
@@ -153,12 +153,16 @@ See `./transmission-rss.conf.example` for more documentation.
 
     fork: false
 
+    single: false
+
     pid_file: false
 
     seen_file: ~/.config/transmission/seen
 
 Daemonized Startup
 ------------------
+
+### As a systemd service
 
 The following content can be saved into
 `/etc/systemd/system/transmission-rss.service` to create a systemd unit.
@@ -179,3 +183,9 @@ Remember checking the path in `ExecStart`.
 The unit files are reloaded by `systemctl daemon-reload`. You can then start
 transmission-rss by running `systemctl start transmission-rss`. Starting on
 boot, can be enabled `systemctl enable transmission-rss`.
+
+### As a cronjob
+
+`transmission-rss` can also be started in a single run mode, in which it runs a single loop and then exits. To do so, `transmission-rss` needs to be started with the `-s` flag. An example crontab line for running every 10 minutes can be:
+
+`*/10 * * * * /usr/local/bin/transmission-rss -s`

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -20,6 +20,9 @@ end
 # Do not fork by default.
 dofork = false
 
+# Do not run single time by default.
+dosingle = false
+
 # No PID file by default.
 pid_file = false
 
@@ -33,6 +36,7 @@ Adds torrents from rss feeds to transmission web frontend.
 
   -c <file>   Custom config file path. Default: #{config_file}
   -f          Fork into background after startup.
+  -s          Single run mode.
   -h          This help.
   -p <file>   Write PID to file.
   -r          Reset seenfile on startup.
@@ -46,6 +50,7 @@ end
 options = GetoptLong.new \
   ['-c', GetoptLong::REQUIRED_ARGUMENT],
   ['-f', GetoptLong::NO_ARGUMENT],
+  ['-s', GetoptLong::NO_ARGUMENT],
   ['-h', GetoptLong::NO_ARGUMENT],
   ['-p', GetoptLong::REQUIRED_ARGUMENT],
   ['-r', GetoptLong::NO_ARGUMENT],
@@ -59,6 +64,8 @@ options.each do |option, argument|
       custom_config = true
     when '-f'
       dofork = true
+    when '-s'
+      dosingle = true
     when '-h'
       usage_message(config_file)
     when '-p'
@@ -105,6 +112,9 @@ log.debug(config)
 
 # Fork value from command line.
 config.fork = dofork if dofork
+
+# Run a single time.
+config.single = dosingle if dosingle
 
 # PID file path from command line.
 config.pid_file = pid_file if pid_file
@@ -174,6 +184,8 @@ begin
       log.debug('wrote pid to ' + config.pid_file)
       File.write(config.pid_file, pid)
     end
+  elsif config.single
+    aggregator.run(-1)
   else
     log.debug('pid ' + Process.pid.to_s)
 

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -74,6 +74,11 @@ module TransmissionRSS
           end
         end
 
+        if interval == -1
+          @log.debug('single run mode, exiting')
+          break
+        end
+
         sleep(interval)
       end
     end

--- a/lib/transmission-rss/config.rb
+++ b/lib/transmission-rss/config.rb
@@ -61,6 +61,7 @@ module TransmissionRSS
           'level' => :debug
         },
         'fork' => false,
+        'single' => false,
         'pid_file' => false,
         'privileges' => {},
         'seen_file' => nil

--- a/transmission-rss.conf.example
+++ b/transmission-rss.conf.example
@@ -77,6 +77,10 @@ feeds:
 
 #fork: false
 
+# Single run mode?
+
+# single: false
+
 # Save PID.
 
 #pid_file: false


### PR DESCRIPTION
Introduce single run mode for `transmissions-rss`. Running `transmission-rss` with the `-s` flag will exit after the first loop, which can be useful for running it as a cronjob.

Fixes https://github.com/nning/transmission-rss/issues/68.