### PR TITLE
Support many new options

### DIFF
--- a/bin/transmission-add-file
+++ b/bin/transmission-add-file
@@ -61,7 +61,7 @@ log.debug(config)
 client = Client.new(config.server, config.login)
 
 ARGV.each do |torrent_file|
-  client.add_torrent(torrent_file, :file, paused: config.add_paused)
+  client.add_torrent(torrent_file, :file, add_paused: config.add_paused)
 end
 
 log.close

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -137,7 +137,11 @@ else
 end
 
 # Feeds can override this on a per-feed or per-match basis
-default_feed_config = {:add_paused => config.add_paused, :download_path => config.download_path}
+default_feed_config = {
+  :add_paused => config.add_paused,
+  :download_path => config.download_path,
+  :priority => config.priority
+}
 
 # Warn if no feeds are given.
 log.warn('no feeds given') if config.feeds.empty?

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -160,7 +160,9 @@ aggregator.on_new_item do |torrent_file, feed, download_path|
   client.add_torrent(torrent_file, :url,
     paused: config.add_paused,
     download_dir: download_path,
-    seed_ratio_limit: feed.config.seed_ratio_limit)
+    seed_ratio_limit: feed.config.seed_ratio_limit,
+    seed_idle_limit: feed.config.seed_idle_limit,
+    priority: feed.config.priority)
 end
 
 # Callback for changes to the config.

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -17,6 +17,14 @@ if bsd?
   config_file = '/usr/local' + config_file
 end
 
+# Options read from the general config section. Feeds can override this on a
+# per-feed or per-match basis. Add here any new option supported at the feed or
+# match level.
+overridable_options = [
+  :download_path, :add_paused, :peer_limit, :priority, :seed_ratio_limit,
+  :seed_idle_limit, :download_limit, :upload_limit, :honor_limits
+]
+
 # Do not fork by default.
 dofork = false
 
@@ -136,12 +144,10 @@ else
   log.debug('no privilege dropping')
 end
 
-# Feeds can override this on a per-feed or per-match basis
-default_feed_config = {
-  :add_paused => config.add_paused,
-  :download_path => config.download_path,
-  :priority => config.priority
-}
+default_feed_config = {}
+overridable_options.each do |o|
+  default_feed_config.merge!(o => config[o.to_s]) unless config[o.to_s].nil?
+end
 
 # Warn if no feeds are given.
 log.warn('no feeds given') if config.feeds.empty?

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -137,7 +137,7 @@ else
 end
 
 # Feeds can override this on a per-feed or per-match basis
-default_feed_config = {:paused => config.add_paused, :download_path => config.download_path}
+default_feed_config = {:add_paused => config.add_paused, :download_path => config.download_path}
 
 # Warn if no feeds are given.
 log.warn('no feeds given') if config.feeds.empty?

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -136,6 +136,9 @@ else
   log.debug('no privilege dropping')
 end
 
+# Feeds can override this on a per-feed or per-match basis
+default_feed_config = {:paused => config.add_paused, :download_path => config.download_path}
+
 # Warn if no feeds are given.
 log.warn('no feeds given') if config.feeds.empty?
 
@@ -156,13 +159,8 @@ end
 client = Client.new(config.server, config.login, config.client)
 
 # Callback for a new item on one of the feeds.
-aggregator.on_new_item do |torrent_file, feed, download_path|
-  client.add_torrent(torrent_file, :url,
-    paused: config.add_paused,
-    download_dir: download_path,
-    seed_ratio_limit: feed.config.seed_ratio_limit,
-    seed_idle_limit: feed.config.seed_idle_limit,
-    priority: feed.config.priority)
+aggregator.on_new_item do |torrent_file, feed, feed_config|
+  client.add_torrent(torrent_file, :url, default_feed_config.merge(feed_config))
 end
 
 # Callback for changes to the config.

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -122,10 +122,10 @@ module TransmissionRSS
 
         @log.debug('on_new_item event ' + link)
 
-        download_path = feed.download_path(item.title)
+        feed_config = feed.get_config(item.title)
 
         begin
-          on_new_item(link, feed, download_path)
+          on_new_item(link, feed, feed_config)
         rescue Client::Unauthorized, Errno::ECONNREFUSED, Timeout::Error
           @log.debug('not added to seen file ' + link)
         else

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -63,17 +63,38 @@ module TransmissionRSS
       log_message << ' (id ' + id.to_s + ')' if id
       @log.debug(log_message)
 
-      if id && options[:seed_ratio_limit]
-        if options[:seed_ratio_limit].to_f < 0
-          set_torrent(id, {
-            'seedRatioMode' => 2
-          })
-        else
-          set_torrent(id, {
-            'seedRatioLimit' => options[:seed_ratio_limit].to_f,
-            'seedRatioMode' => 1
-          })
+      if id
+
+        set_opts = {}
+
+        if options[:seed_ratio_limit]
+          if options[:seed_ratio_limit].to_f < 0
+            set_opts[:seedRatioMode] = 2
+          else
+            set_opts[:seedRatioMode] = 1
+            set_opts[:seedRatioLimit] = options[:seed_ratio_limit].to_f
+          end
         end
+
+        if options[:seed_idle_limit]
+          if options[:seed_idle_limit].to_i < 0
+            set_opts[:seedIdleMode] = 2
+          else
+            set_opts[:seedIdleMode] = 1
+            set_opts[:seedIdleLimit] = options[:seed_idle_limit].to_i
+          end
+        end
+
+        if options[:priority]
+          if options[:priority].eql?('low')
+            set_opts[:bandwidthPriority] = -1
+          elsif options[:priority].eql?('high')
+            set_opts[:bandwidthPriority] = 1
+          end
+        end
+
+        set_torrent(id, set_opts) unless set_opts.empty?
+
       end
 
       response

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -7,7 +7,6 @@ require File.join(File.dirname(__FILE__), 'log')
 module TransmissionRSS
   # Class for communication with transmission utilizing the RPC web interface.
   class Client
-    OPTIONS = {:add_paused => :'paused', :download_path => :'download-dir'}
 
     class Unauthorized < StandardError
     end
@@ -82,16 +81,6 @@ module TransmissionRSS
           else
             set_opts[:seedIdleMode] = 1
             set_opts[:seedIdleLimit] = options[:seed_idle_limit].to_i
-          end
-        end
-
-        if options[:priority] && !options[:priority].eql?('default')
-          if options[:priority].eql?('low')
-            set_opts[:bandwidthPriority] = -1
-          elsif options[:priority].eql?('high')
-            set_opts[:bandwidthPriority] = 1
-          elsif options[:priority].eql?('normal')
-            set_opts[:bandwidthPriority] = 0
           end
         end
 
@@ -172,8 +161,22 @@ module TransmissionRSS
     def set_arguments_from_options(options)
       arguments = {}
 
-      OPTIONS.each do |key, value|
-        arguments[value] = options[key] unless options[key].nil? || options[key].eql?('default')
+      options.each do |key, value|
+        next if value.nil? || value.eql?('default')
+        case key
+        when :add_paused
+          arguments[:paused] = value
+        when :download_path
+          arguments[:'download-dir'] = value
+        when :priority
+          if value.eql?('low')
+            arguments[:bandwidthPriority] = -1
+          elsif value.eql?('high')
+            arguments[:bandwidthPriority] = 1
+          elsif value.eql?('normal')
+            arguments[:bandwidthPriority] = 0
+          end
+        end
       end
 
       arguments

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -64,10 +64,16 @@ module TransmissionRSS
       @log.debug(log_message)
 
       if id && options[:seed_ratio_limit]
-        set_torrent(id, {
-          'seedRatioLimit' => options[:seed_ratio_limit].to_f,
-          'seedRatioMode' => 1
-        })
+        if options[:seed_ratio_limit].to_f < 0
+          set_torrent(id, {
+            'seedRatioMode' => 2
+          })
+        else
+          set_torrent(id, {
+            'seedRatioLimit' => options[:seed_ratio_limit].to_f,
+            'seedRatioMode' => 1
+          })
+        end
       end
 
       response

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -173,7 +173,7 @@ module TransmissionRSS
       arguments = {}
 
       OPTIONS.each do |key, value|
-        arguments[value] = options[key] unless options[key].nil?
+        arguments[value] = options[key] unless options[key].nil? || options[key].eql?('default')
       end
 
       arguments

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -84,6 +84,20 @@ module TransmissionRSS
           end
         end
 
+        if options[:download_limit] && !options[:download_limit].eql?('default') && options[:download_limit].to_i >= 0
+          set_opts[:downloadLimit] = options[:download_limit].to_i
+          set_opts[:downloadLimited] = true
+        end
+
+        if options[:upload_limit] && !options[:upload_limit].eql?('default') && options[:upload_limit].to_i >= 0
+          set_opts[:uploadLimit] = options[:upload_limit].to_i
+          set_opts[:uploadLimited] = true
+        end
+
+        if !options[:honor_limits].nil? && !options[:honor_limits].eql?('default')
+          set_opts[:honorsSessionLimits] = !!options[:honor_limits]
+        end
+
         set_torrent(id, set_opts) unless set_opts.empty?
 
       end
@@ -162,12 +176,16 @@ module TransmissionRSS
       arguments = {}
 
       options.each do |key, value|
+
         next if value.nil? || value.eql?('default')
+
         case key
-        when :add_paused
-          arguments[:paused] = value
         when :download_path
           arguments[:'download-dir'] = value
+        when :add_paused
+          arguments[:paused] = value
+        when :peer_limit
+          arguments[:'peer-limit'] = value.to_i
         when :priority
           if value.eql?('low')
             arguments[:bandwidthPriority] = -1
@@ -177,6 +195,7 @@ module TransmissionRSS
             arguments[:bandwidthPriority] = 0
           end
         end
+
       end
 
       arguments

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -7,7 +7,7 @@ require File.join(File.dirname(__FILE__), 'log')
 module TransmissionRSS
   # Class for communication with transmission utilizing the RPC web interface.
   class Client
-    OPTIONS = [:paused, :download_dir]
+    OPTIONS = {:add_paused => :'paused', :download_path => :'download-dir'}
 
     class Unauthorized < StandardError
     end
@@ -67,7 +67,7 @@ module TransmissionRSS
 
         set_opts = {}
 
-        if options[:seed_ratio_limit]
+        if options[:seed_ratio_limit] && !options[:seed_ratio_limit].eql?('default')
           if options[:seed_ratio_limit].to_f < 0
             set_opts[:seedRatioMode] = 2
           else
@@ -76,7 +76,7 @@ module TransmissionRSS
           end
         end
 
-        if options[:seed_idle_limit]
+        if options[:seed_idle_limit] && !options[:seed_idle_limit].eql?('default')
           if options[:seed_idle_limit].to_i < 0
             set_opts[:seedIdleMode] = 2
           else
@@ -85,11 +85,13 @@ module TransmissionRSS
           end
         end
 
-        if options[:priority]
+        if options[:priority] && !options[:priority].eql?('default')
           if options[:priority].eql?('low')
             set_opts[:bandwidthPriority] = -1
           elsif options[:priority].eql?('high')
             set_opts[:bandwidthPriority] = 1
+          elsif options[:priority].eql?('normal')
+            set_opts[:bandwidthPriority] = 0
           end
         end
 
@@ -170,10 +172,8 @@ module TransmissionRSS
     def set_arguments_from_options(options)
       arguments = {}
 
-      OPTIONS.each do |o|
-        unless options[o].nil?
-          arguments[o.to_s.sub('_', '-')] = options[o]
-        end
+      OPTIONS.each do |key, value|
+        arguments[value] = options[key] unless options[key].nil?
       end
 
       arguments

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -28,13 +28,13 @@ module TransmissionRSS
     end
 
     def get_config(title = nil)
-      return config[:'(.*?)'] if title.nil?
+      return matcher_configs[:'(.*?)'] if title.nil?
 
       matcher_configs.each do |regexp, config|
         return config if title =~ to_regexp(regexp)
       end
 
-      config['(.*?)']
+      matcher_configs['(.*?)']
     end
 
     def matches_regexp?(title)


### PR DESCRIPTION
The following options have been added:

- peer_limit
- priority
- seed_idle_limit
- download_limit
- upload_limit
- honor_limits

The config structure has been reworked: now every option can be specified at the global, feed or match level.
Every match is treated the same way and when no match is specified a catch-all match is created; this allows us to simplify the logic a bit.

Documentation needs to be updated.

This PR includes and supersedes #108 