### PR TITLE
Add seen_by_guid property to feeds for dynamic link feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ feeds:
     validate_cert: false
 ```
 
+Using the GUID instead of the link for tracking seen torrents is also available,
+useful for changing URLs such as Prowlarr's proxy links. Default is false:
+
+```yaml
+feeds:
+  - url: http://example.com/feed1
+    seen_by_guid: true
+```
+
 ### All available options
 
 The following configuration file example contains every existing option
@@ -150,6 +159,7 @@ feeds:
         download_path: /home/user/match2
   - url: http://example.com/feed9
     validate_cert: false
+    seen_by_guid: true
 
 update_interval: 600
 

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -114,7 +114,7 @@ module TransmissionRSS
       
       # Determine whether to use guid or link as seen hash
       seen_value = !!feed.seen_by_guid ? (item.guid.content rescue item.guid || link).to_s : link
-
+      
       # The link is not in +@seen+ Array.
       unless @seen.include?(seen_value)
         # Skip if filter defined and not matching.

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -113,7 +113,7 @@ module TransmissionRSS
       link = link.href if link.class != String
       
       # Determine whether to use guid or link as seen hash
-      seen_value = !!feed.seen_by_guid ? (item.guid.content rescue item.guid || link).to_s : link
+      seen_value = feed.seen_by_guid ? (item.guid.content rescue item.guid || link).to_s : link
       
       # The link is not in +@seen+ Array.
       unless @seen.include?(seen_value)

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -111,12 +111,15 @@ module TransmissionRSS
 
       # Link is not a String directly.
       link = link.href if link.class != String
+      
+      # Determine whether to use guid or link as seen hash
+      seen_value = !!feed.seen_by_guid ? (item.guid.content || item.guid || link).to_s : link
 
       # The link is not in +@seen+ Array.
-      unless @seen.include?(link)
+      unless @seen.include?(seen_value)
         # Skip if filter defined and not matching.
         unless feed.matches_regexp?(item.title)
-          @seen.add(link)
+          @seen.add(seen_value)
           return
         end
 
@@ -129,7 +132,7 @@ module TransmissionRSS
         rescue Client::Unauthorized, Errno::ECONNREFUSED, Timeout::Error
           @log.debug('not added to seen file ' + link)
         else
-          @seen.add(link)
+          @seen.add(seen_value)
         end
       end
 

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -113,7 +113,7 @@ module TransmissionRSS
       link = link.href if link.class != String
       
       # Determine whether to use guid or link as seen hash
-      seen_value = !!feed.seen_by_guid ? (item.guid.content || item.guid || link).to_s : link
+      seen_value = !!feed.seen_by_guid ? (item.guid.content rescue item.guid || link).to_s : link
 
       # The link is not in +@seen+ Array.
       unless @seen.include?(seen_value)

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -12,8 +12,6 @@ module TransmissionRSS
         @url = URI.escape(URI.unescape(config['url'] || config.keys.first))
 
         @download_path = config['download_path']
-        @validate_cert = config['validate_cert'].nil? || !!config['validate_cert']
-        @seen_by_guid = !!config['seen_by_guid']
 
         matchers = Array(config['regexp']).map do |e|
           e.is_a?(String) ? e : e['matcher']
@@ -26,6 +24,9 @@ module TransmissionRSS
         @config = {}
         @url = config.to_s
       end
+
+      @validate_cert = @config['validate_cert'].nil? || !!@config['validate_cert']
+      @seen_by_guid = !!@config['seen_by_guid']
     end
 
     def download_path(title = nil)

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -12,8 +12,8 @@ module TransmissionRSS
         @url = URI.escape(URI.unescape(config['url'] || config.keys.first))
 
         @download_path = config['download_path']
-        @validate_cert = !!config['validate_cert']
-        @seen_by_guid = config['seen_by_guid'].nil? || config['seen_by_guid']
+        @validate_cert = config['validate_cert'].nil? || !!config['validate_cert']
+        @seen_by_guid = !!config['seen_by_guid']
 
         matchers = Array(config['regexp']).map do |e|
           e.is_a?(String) ? e : e['matcher']

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -1,6 +1,6 @@
 module TransmissionRSS
   class Feed
-    attr_reader :url, :regexp, :config, :validate_cert
+    attr_reader :url, :regexp, :config, :validate_cert, :seen_by_guid
 
     def initialize(config = {})
       @download_paths = {}
@@ -12,7 +12,8 @@ module TransmissionRSS
         @url = URI.escape(URI.unescape(config['url'] || config.keys.first))
 
         @download_path = config['download_path']
-        @validate_cert = config['validate_cert'].nil? || config['validate_cert']
+        @validate_cert = !!config['validate_cert']
+        @seen_by_guid = config['seen_by_guid'].nil? || config['seen_by_guid']
 
         matchers = Array(config['regexp']).map do |e|
           e.is_a?(String) ? e : e['matcher']

--- a/spec/aggregator_spec.rb
+++ b/spec/aggregator_spec.rb
@@ -51,4 +51,42 @@ describe Aggregator do
       end
     end
   end
+
+  describe '#process_link' do
+    before(:each) do    
+      VCR.use_cassette('feed_fetch', MATCH_REQUESTS_ON) do  
+        ITEM = subject.send(:parse, subject.send(:fetch, FEEDS.first)).first
+      end
+    end
+
+    it 'returns enclosure link' do
+      content = subject.send(:process_link, FEEDS.first, ITEM)
+
+      url = URI.parse(content)
+
+      expect(url.scheme).to eq('https')
+      expect(url.host).to eq('www.archlinux.org')
+      expect(File.basename(url.path)).to match(/\.iso\.torrent$/)
+    end
+
+    it 'returns link if no enclosure link' do
+      ITEM.enclosure = nil
+      
+      content = subject.send(:process_link, FEEDS.first, ITEM)
+
+      url = URI.parse(content)
+      expect(url.scheme).to eq('https')
+      expect(url.host).to eq('www.archlinux.org')
+      expect(File.basename(url.path)).to match(/2020\.01\.01$/)
+    end
+
+    it 'returns nil if no link or enclosure link' do
+      ITEM.enclosure = nil
+      ITEM.link = nil
+      
+      content = subject.send(:process_link, FEEDS.first, ITEM)
+
+      expect(content).to be_nil
+    end
+  end
 end

--- a/spec/aggregator_spec.rb
+++ b/spec/aggregator_spec.rb
@@ -55,38 +55,47 @@ describe Aggregator do
   describe '#process_link' do
     before(:each) do    
       VCR.use_cassette('feed_fetch', MATCH_REQUESTS_ON) do  
-        ITEM = subject.send(:parse, subject.send(:fetch, FEEDS.first)).first
+        @item = subject.send(:parse, subject.send(:fetch, FEEDS.first)).first
       end
+      subject.seen.clear!
     end
 
-    it 'returns enclosure link' do
-      content = subject.send(:process_link, FEEDS.first, ITEM)
+    it 'returns enclosure link and adds to seen' do
+      content = subject.send(:process_link, FEEDS.first, @item)
 
       url = URI.parse(content)
 
       expect(url.scheme).to eq('https')
       expect(url.host).to eq('www.archlinux.org')
       expect(File.basename(url.path)).to match(/\.iso\.torrent$/)
+      
+      expect(subject.seen.size).to eq(1)
+      expect(subject.seen.include?(content)).to be true
     end
 
-    it 'returns link if no enclosure link' do
-      ITEM.enclosure = nil
+    it 'returns link and adds to seen if no enclosure link' do
+      @item.enclosure = nil
       
-      content = subject.send(:process_link, FEEDS.first, ITEM)
+      content = subject.send(:process_link, FEEDS.first, @item)
 
       url = URI.parse(content)
       expect(url.scheme).to eq('https')
       expect(url.host).to eq('www.archlinux.org')
       expect(File.basename(url.path)).to match(/2020\.01\.01$/)
+      
+      expect(subject.seen.size).to eq(1)
+      expect(subject.seen.include?(content)).to be true
     end
 
     it 'returns nil if no link or enclosure link' do
-      ITEM.enclosure = nil
-      ITEM.link = nil
+      @item.enclosure = nil
+      @item.link = nil
       
-      content = subject.send(:process_link, FEEDS.first, ITEM)
+      content = subject.send(:process_link, FEEDS.first, @item)
 
       expect(content).to be_nil
+      
+      expect(subject.seen.size).to eq(0)
     end
   end
 end

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -32,12 +32,12 @@ describe Feed do
   end
 
   it 'should be able to parse old style with all options' do
-    feed = Feed.new({@url => nil, 'download_path' => @download_path, 'regexp' => @matcher, 'validate_cert': true, 'seen_by_guid': false})
+    feed = Feed.new({@url => nil, 'download_path' => @download_path, 'regexp' => @matcher, 'validate_cert' => true, 'seen_by_guid' => false})
     expect(feed.url).to eq(@url)
     expect(feed.download_path).to eq(@download_path)
     expect(feed.regexp).to eq(@regexp)
-    expect(feed.validate_cert).to eq(false)
-    expect(feed.seen_by_guid).to eq(true)
+    expect(feed.validate_cert).to eq(true)
+    expect(feed.seen_by_guid).to eq(false)
   end
 
   it 'should be able to use new style config with no options' do
@@ -48,7 +48,7 @@ describe Feed do
   end
 
   it 'should be able to use new style config with all options' do
-    feed = Feed.new({'url' => @url, 'download_path' => @download_path, 'regexp' => @matcher, 'validate_cert': false, 'seen_by_guid': true})
+    feed = Feed.new({'url' => @url, 'download_path' => @download_path, 'regexp' => @matcher, 'validate_cert' => false, 'seen_by_guid' => true})
     expect(feed.url).to eq(@url)
     expect(feed.download_path).to eq(@download_path)
     expect(feed.regexp).to eq(@regexp)

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -15,8 +15,8 @@ describe Feed do
     expect(feed.config).not_to be_nil
     expect(feed.download_path).to be_nil
     expect(feed.regexp).to be_nil
-    expect(feed.validate_cert).to be_nil
-    expect(feed.seen_by_guid).to be_nil
+    expect(feed.validate_cert).to eq(true)
+    expect(feed.seen_by_guid).to eq(false)
   end
 
   it 'should be able to parse encoded url' do

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -29,6 +29,8 @@ describe Feed do
     expect(feed.url).to eq(@url)
     expect(feed.download_path).to be_nil
     expect(feed.regexp).to be_nil
+    expect(feed.validate_cert).to eq(true)
+    expect(feed.seen_by_guid).to eq(false)
   end
 
   it 'should be able to parse old style with all options' do

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -15,6 +15,8 @@ describe Feed do
     expect(feed.config).not_to be_nil
     expect(feed.download_path).to be_nil
     expect(feed.regexp).to be_nil
+    expect(feed.validate_cert).to be_nil
+    expect(feed.seen_by_guid).to be_nil
   end
 
   it 'should be able to parse encoded url' do
@@ -29,11 +31,13 @@ describe Feed do
     expect(feed.regexp).to be_nil
   end
 
-  it 'should be able to parse old style with both options' do
-    feed = Feed.new({@url => nil, 'download_path' => @download_path, 'regexp' => @matcher})
+  it 'should be able to parse old style with all options' do
+    feed = Feed.new({@url => nil, 'download_path' => @download_path, 'regexp' => @matcher, 'validate_cert': true, 'seen_by_guid': false})
     expect(feed.url).to eq(@url)
     expect(feed.download_path).to eq(@download_path)
     expect(feed.regexp).to eq(@regexp)
+    expect(feed.validate_cert).to eq(false)
+    expect(feed.seen_by_guid).to eq(true)
   end
 
   it 'should be able to use new style config with no options' do
@@ -44,10 +48,12 @@ describe Feed do
   end
 
   it 'should be able to use new style config with all options' do
-    feed = Feed.new({'url' => @url, 'download_path' => @download_path, 'regexp' => @matcher})
+    feed = Feed.new({'url' => @url, 'download_path' => @download_path, 'regexp' => @matcher, 'validate_cert': false, 'seen_by_guid': true})
     expect(feed.url).to eq(@url)
     expect(feed.download_path).to eq(@download_path)
     expect(feed.regexp).to eq(@regexp)
+    expect(feed.validate_cert).to eq(false)
+    expect(feed.seen_by_guid).to eq(true)
   end
 
   it 'should have a functioning matcher' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,3 +19,8 @@ VCR.configure do |config|
 end
 
 MATCH_REQUESTS_ON = { match_requests_on: [:method, :uri, :headers, :body] }
+
+RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+end

--- a/transmission-rss.conf.example
+++ b/transmission-rss.conf.example
@@ -31,6 +31,7 @@ feeds:
         download_path: /home/user/match2
   - url: http://example.com/feed8
     validate_cert: false
+    seen_by_guid: true
 
 # Feed probing interval in seconds. Default is 600.
 


### PR DESCRIPTION
I recently moved from Jackett to Prowlarr and noticed that some torrents were being re-added to my download client despite entries being added to my `seen_file`. After some investigation. I realized it was because Prowlarr "proxies" the download link to go through itself rather than directly to the result and in doing so generates a unique URL. The problem was that this URL is not static and changes for each request, so my seen_file was never matching on the URL and bloating with hashes for the same torrent over and over.

To fix this, I've added an option called `seen_by_guid` to the `feed` object. This, as the name implies, will use the `guid` on the feed item, which should be consistent. This defaults to `false` to prevent invalidating existing seen files and falls back to the link if there is no guid element in the result.

I've also added tests for the areas I've impacted to try and ensure I didn't break anything. All tests pass and it seems to be behaving correctly in Docker with and without `seen_by_guid` from my manual testing.

Let me know if you'd like any changes, and thank you for creating transmission-rss.