### PR TITLE
Add labels option to the feed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ feeds:
     regexp: (match1|match2)
   - url: http://example.com/feed5
     download_path: /home/user/Downloads
+    labels: ["movies", "comedy"]
   - url: http://example.com/feed6
     seed_ratio_limit: 1
   - url: http://example.com/feed7

--- a/bin/transmission-rss
+++ b/bin/transmission-rss
@@ -161,7 +161,8 @@ aggregator.on_new_item do |torrent_file, feed, download_path|
   client.add_torrent(torrent_file, :url,
     paused: config.add_paused,
     download_dir: download_path,
-    seed_ratio_limit: feed.config.seed_ratio_limit)
+    seed_ratio_limit: feed.config.seed_ratio_limit,
+    labels: feed.config.labels)
 end
 
 # Callback for changes to the config.

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -56,6 +56,10 @@ module TransmissionRSS
           raise ArgumentError.new('type has to be :url or :file.')
       end
 
+      if options[:labels]
+        arguments.labels = options[:labels]
+      end
+
       response = rpc('torrent-add', arguments)
       id = get_id_from_response(response)
 

--- a/transmission-rss.conf.example
+++ b/transmission-rss.conf.example
@@ -19,6 +19,7 @@ feeds:
     regexp: (match1|match2)
   - url: http://example.com/feed5
     download_path: /home/user/Downloads
+    labels: ["movies", "comedy"] # Array of labels to apply to torrents added
   - url: http://example.com/feed6
     regexp:
       - match1


### PR DESCRIPTION
I wanted to automatically label the torrents from my rss feeds to easily sort through them in the GUI.

I figured I'd put a pull request in for this as well, because someone else might find it useful.