### PR TITLE
Add ruby 3.4+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,19 @@ os:
   - osx
 
 rvm:
-  - 2.7 # Current stable
-  - 2.6 # Alpine 3.11
-  - 2.5 # Debian stable (buster), Ubuntu
-  - 2.1 # Minimum supported version (Debian oldoldstable (jessie))
+  - 3.4 # Latest stable version
+  - 3.2 # LTS
+  - 3.0 # Minimum supported version
 
 matrix:
   fast_finish: true
   allow_failures:
     - os: osx
-    - rvm: ruby-head
-  exclude:
-    - os: osx
-      rvm: ruby-head
-    - os: osx
-      rvm: 2.1
 
 notifications:
   email: false
 
 install:
-  - gem install bundler -v '< 2'
   - bundle install --jobs=3 --retry=3
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@
 # docker tag nning2/transmission-rss:v1.2.3 nning2/transmission-rss:latest
 # docker push nning2/transmission-rss:v1.2.3
 
-FROM alpine:3 as builder
+FROM alpine:3.23 AS builder
 RUN apk add gcc libc-dev make ruby-dev
 COPY . /tmp
 WORKDIR /tmp
 RUN gem build transmission-rss.gemspec
 RUN gem install -N --build-root /build transmission-rss-*.gem
 
-FROM alpine:3
+FROM alpine:3.23
 ARG UID=1000
 ARG GID=1000
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@
 # docker tag nning2/transmission-rss:v1.2.3 nning2/transmission-rss:latest
 # docker push nning2/transmission-rss:v1.2.3
 
-FROM alpine:3 as builder
+FROM alpine:3.22 AS builder
 RUN apk add gcc libc-dev make ruby-dev
 COPY . /tmp
 WORKDIR /tmp
 RUN gem build transmission-rss.gemspec
 RUN gem install -N --build-root /build transmission-rss-*.gem
 
-FROM alpine:3
+FROM alpine:3.22
 ARG UID=1000
 ARG GID=1000
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG GID=1000
 RUN \
   addgroup -g $GID ruby && \
   adduser -u $UID -G ruby -D ruby && \
-  apk add --no-cache ruby ruby-etc ruby-json
+  apk add --no-cache ruby
 USER ruby
 COPY --from=builder /build /
 CMD ["transmission-rss"]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ torrent files.
 As it's done with poems, I devote this very artful and romantic piece of
 code to the single most delightful human being: Ann.
 
-The minimum supported Ruby version is 2.1. (You will need `rbenv` if your
-os does not support Ruby >= 2.1, e.g. on Debian wheezy.)
+The minimum supported Ruby version is 3.0.
 
 **Note, that this README is for the current development branch!** You can find
 a link to a suitable README for your version

--- a/lib/transmission-rss.rb
+++ b/lib/transmission-rss.rb
@@ -5,7 +5,6 @@ end
 
 require 'transmission-rss/core_ext/Array'
 require 'transmission-rss/core_ext/Object'
-require 'transmission-rss/core_ext/URI'
 
 Dir.glob($:.first + '/**/*.rb').each do |lib|
 	require lib

--- a/lib/transmission-rss.rb
+++ b/lib/transmission-rss.rb
@@ -5,7 +5,7 @@ end
 
 require 'transmission-rss/core_ext/Array'
 require 'transmission-rss/core_ext/Object'
-require 'transmission-rss/core_ext/URI'
+require 'transmission-rss/uri_helper'
 
 Dir.glob($:.first + '/**/*.rb').each do |lib|
 	require lib

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -51,9 +51,6 @@ module TransmissionRSS
             next
           end
 
-          # gzip HTTP Content-Encoding is not automatically decompressed in
-          # Ruby 1.9.3.
-          content = decompress(content) if RUBY_VERSION == '1.9.3'
           begin
             items = parse(content)
           rescue StandardError => e
@@ -89,18 +86,12 @@ module TransmissionRSS
         options[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE
       end
 
-      # open for URIs is obsolete, URI.open does not work in 2.4
-      URI.send(:open, feed.url, options).read
+      # Use URI.open for Ruby 3.x compatibility
+      URI.open(feed.url, options).read
     end
 
     def parse(content)
       RSS::Parser.parse(content, false).items
-    end
-
-    def decompress(string)
-      Zlib::GzipReader.new(StringIO.new(string)).read
-    rescue Zlib::GzipFile::Error, Zlib::Error
-      string
     end
 
     def process_link(feed, item)

--- a/lib/transmission-rss/aggregator.rb
+++ b/lib/transmission-rss/aggregator.rb
@@ -89,8 +89,8 @@ module TransmissionRSS
         options[:ssl_verify_mode] = OpenSSL::SSL::VERIFY_NONE
       end
 
-      # open for URIs is obsolete, URI.open does not work in 2.4
-      URI.send(:open, feed.url, options).read
+      # Use URI.open for Ruby 3.x compatibility
+      URI.open(feed.url, options).read
     end
 
     def parse(content)

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -1,12 +1,14 @@
 require 'net/http'
 require 'json'
 require 'base64'
+require 'timeout'
 
 require File.join(File.dirname(__FILE__), 'log')
 
 module TransmissionRSS
   # Class for communication with transmission utilizing the RPC web interface.
   class Client
+    include URIHelper
     OPTIONS = [:paused, :download_dir]
 
     class Unauthorized < StandardError
@@ -57,8 +59,7 @@ module TransmissionRSS
 
       case type
         when :url
-          file = URI.escape(file) if URI.unescape(file) == file
-          arguments.filename = file
+          arguments.filename = normalize_url(file)
         when :file
           arguments.metainfo = Base64.encode64(File.read(file))
         else

--- a/lib/transmission-rss/client.rb
+++ b/lib/transmission-rss/client.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'json'
 require 'base64'
+require 'timeout'
 
 require File.join(File.dirname(__FILE__), 'log')
 
@@ -57,7 +58,6 @@ module TransmissionRSS
 
       case type
         when :url
-          file = URI.escape(file) if URI.unescape(file) == file
           arguments.filename = file
         when :file
           arguments.metainfo = Base64.encode64(File.read(file))

--- a/lib/transmission-rss/core_ext/URI.rb
+++ b/lib/transmission-rss/core_ext/URI.rb
@@ -1,9 +1,0 @@
-module URI
-  def self.escape(*arg)
-    URI::DEFAULT_PARSER.escape(*arg)
-  end
-
-  def self.unescape(*arg)
-    URI::DEFAULT_PARSER.unescape(*arg)
-  end
-end

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -10,7 +10,7 @@ module TransmissionRSS
       when Hash
         @config = config
 
-        @url = URI.escape(URI.unescape(config['url'] || config.keys.first))
+        @url = config['url'] || config.keys.first
 
         @download_path = config['download_path']
 

--- a/lib/transmission-rss/feed.rb
+++ b/lib/transmission-rss/feed.rb
@@ -1,5 +1,6 @@
 module TransmissionRSS
   class Feed
+    include URIHelper
     attr_reader :url, :regexp, :config, :validate_cert, :seen_by_guid, :delay_time
 
     def initialize(config = {})
@@ -10,7 +11,8 @@ module TransmissionRSS
       when Hash
         @config = config
 
-        @url = URI.escape(URI.unescape(config['url'] || config.keys.first))
+        raw_url = config['url'] || config.keys.first
+        @url = normalize_url(raw_url)
 
         @download_path = config['download_path']
 

--- a/lib/transmission-rss/seen_file.rb
+++ b/lib/transmission-rss/seen_file.rb
@@ -24,14 +24,14 @@ module TransmissionRSS
 
       @seen << hash
 
-      open(@path, 'a') do |f|
+      File.open(@path, 'a') do |f|
         f.write(hash + "\n")
       end
     end
 
     def clear!
       @seen.clear
-      open(@path, 'w') {}
+      File.open(@path, 'w') {}
     end
 
     def include?(url)
@@ -49,7 +49,7 @@ module TransmissionRSS
     end
 
     def file_to_array(path)
-      open(path, 'r').readlines.map(&:chomp)
+      File.open(path, 'r').readlines.map(&:chomp)
     end
 
     def initialize_path!(path)

--- a/lib/transmission-rss/seen_file.rb
+++ b/lib/transmission-rss/seen_file.rb
@@ -24,14 +24,14 @@ module TransmissionRSS
 
       @seen << hash
 
-      open(@path, 'a') do |f|
+      File.open(@path, 'a') do |f|
         f.write(hash + "\n")
       end
     end
 
     def clear!
       @seen.clear
-      open(@path, 'w') {}
+      File.open(@path, 'w') {}
     end
 
     def include?(url)
@@ -49,7 +49,7 @@ module TransmissionRSS
     end
 
     def file_to_array(path)
-      open(path, 'r').readlines.map(&:chomp)
+      File.open(path, 'r') { |f| f.readlines.map(&:chomp) }
     end
 
     def initialize_path!(path)

--- a/lib/transmission-rss/uri_helper.rb
+++ b/lib/transmission-rss/uri_helper.rb
@@ -1,0 +1,15 @@
+require 'uri'
+
+module TransmissionRSS
+  module URIHelper
+    # Normalizes a URL by percent-encoding characters that are invalid in a URI
+    # while preserving existing valid percent-encoded sequences (e.g. %20, %2F).
+    def normalize_url(url)
+      url.gsub(/[^\w\-.~:\/?\[\]@!$&'()*+,;=%]|%(?![0-9A-Fa-f]{2})/) do |c|
+        URI::DEFAULT_PARSER.escape(c)
+      end
+    end
+
+    private :normalize_url
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -65,9 +65,21 @@ describe Client do
       end
 
       VCR.use_cassette('add_torrent_via_http_with_special_chars', MATCH_REQUESTS_ON) do
-        response = Client.new.add_torrent(URI.escape(http_url), :url)
+        response = Client.new.add_torrent(URI::DEFAULT_PARSER.escape(http_url), :url)
         expect(response.result).to eq('success')
       end
+    end
+
+    it 'normalizes partially encoded url' do
+      mixed_url = 'https://nning.io/already%20encoded and raw.torrent'
+      expected  = 'https://nning.io/already%20encoded%20and%20raw.torrent'
+      expect(Client.new.send(:normalize_url, mixed_url)).to eq(expected)
+    end
+
+    it 'encodes raw # in url path' do
+      url_with_hash = 'https://nning.io/file#1.torrent'
+      expected      = 'https://nning.io/file%231.torrent'
+      expect(Client.new.send(:normalize_url, url_with_hash)).to eq(expected)
     end
 
     it 'should raise TooManyRequests' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -65,7 +65,7 @@ describe Client do
       end
 
       VCR.use_cassette('add_torrent_via_http_with_special_chars', MATCH_REQUESTS_ON) do
-        response = Client.new.add_torrent(URI.escape(http_url), :url)
+        response = Client.new.add_torrent(URI.encode_www_form_component(http_url), :url)
         expect(response.result).to eq('success')
       end
     end

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -24,6 +24,18 @@ describe Feed do
     expect(feed.url).to eq(@encoded_url['url'])
   end
 
+  it 'should escape unencoded url' do
+    raw_url = { 'url' => 'http://site.com/rss?name=name with space' }
+    feed = Feed.new(raw_url)
+    expect(feed.url).to eq('http://site.com/rss?name=name%20with%20space')
+  end
+
+  it 'should handle partially encoded url' do
+    mixed_url = { 'url' => 'http://site.com/rss?x=already%20encoded&title=raw space' }
+    feed = Feed.new(mixed_url)
+    expect(feed.url).to eq('http://site.com/rss?x=already%20encoded&title=raw%20space')
+  end
+
   it 'should be able to parse old style hash with no options' do
     feed = Feed.new({@url => nil})
     expect(feed.url).to eq(@url)

--- a/transmission-rss.gemspec
+++ b/transmission-rss.gemspec
@@ -17,9 +17,18 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('{bin,lib}/**/*').push 'README.md', 'transmission-rss.conf.example'
   s.executables = Dir.glob('bin/**').map { |x| x[4..-1] }
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 3.0'
 
-  s.add_dependency 'rss', '~> 0.2', '>= 0.2.9'
+  s.add_dependency 'rss', '~> 0.3'
   s.add_dependency 'open_uri_redirections', '~> 0.2', '>= 0.2.1'
-  s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.10'
+  s.add_dependency 'rb-inotify', '~> 0.10'
+
+  # Standard library gems extracted in Ruby 3.x
+  s.add_dependency 'base64', '~> 0.2'
+  s.add_dependency 'digest', '~> 3.1'
+  s.add_dependency 'etc', '~> 1.4'
+  s.add_dependency 'fileutils', '~> 1.7'
+  s.add_dependency 'getoptlong', '~> 0.2'
+  s.add_dependency 'json', '~> 2.7'
+  s.add_dependency 'logger', '~> 1.6'
 end


### PR DESCRIPTION
Update codebase to be fully compatible with Ruby 3.4.9 (latest version
in Alpine 3.23 container image) by addressing deprecated APIs and
adding missing standard library dependencies.

Changes:
- Update minimum Ruby version requirement from 2.1 to 3.0
- Add explicit dependencies for standard library gems extracted in Ruby 3.x
- Update gem version constraints to use pessimistic versioning (~>)
- Add missing 'timeout' require in `client.rb`
- Replace deprecated URI.escape/URI.unescape with URI::DEFAULT_PARSER equivalents, preserving idempotent encoding behavior
- Remove deprecated URI.escape/unescape usage.
- Replace URI.send(:open) with direct `URI.open` call in `aggregator.rb`
- Replace bare open() calls with explicit `File.open()` for security
- Update `Dockerfile` to remove non-existent Alpine (latest, 3.22) packages (ruby-etc,
  ruby-json) and rely on gem-based dependencies instead
- Update test to use URI::DEFAULT_PARSER.escape instead of deprecated URI.escape
- Base container image version was fixed to 3.23 for a consistent build environment

Breaking Changes:
- Requires Ruby 3.0 or higher

Edited: Container image base Alpine version to 3.23 (latest stable).

The application now works with modern Ruby versions while maintaining
clean, maintainable code without monkey patches.